### PR TITLE
feat(repository): Sorted w/ open PRs & separated open & draft PRs

### DIFF
--- a/src/components/Repositories/RepositoryCard.tsx
+++ b/src/components/Repositories/RepositoryCard.tsx
@@ -16,19 +16,27 @@ import { Visibility } from "@mui/icons-material";
 export type RepositoryCardProps = {
   name: string;
   pulls: PullRequest[];
+  openCount: number;
+  draftCount: number;
 };
 
-export const RepositoryCard: React.FC<RepositoryCardProps> = ({ pulls }) => {
+export const RepositoryCard: React.FC<RepositoryCardProps> = ({
+  pulls,
+  openCount,
+  draftCount,
+}) => {
   const [
     {
       base: { repo },
     },
   ] = pulls;
 
-  const oldestPr = useMemo(() => {
-    return pulls.sort(
-      (prA, prB) => prA.created_at.getTime() - prB.created_at.getTime()
-    )[0];
+  const oldestOpenPr = useMemo(() => {
+    return pulls
+      .filter((pr) => !pr.draft) // Exclude draft PRs
+      .sort(
+        (prA, prB) => prA.created_at.getTime() - prB.created_at.getTime()
+      )[0]; // Get the oldest PR
   }, [pulls]);
 
   return (
@@ -70,17 +78,26 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({ pulls }) => {
           }}
         >
           <Typography color="text.secondary">Max Days: </Typography>
-          <Chip
-            label={Math.floor(
-              (new Date().getTime() - oldestPr.created_at?.getTime()) /
-                (1000 * 3600 * 24)
-            )}
-            size="small"
-            sx={{ bgcolor: getColorForDaysInReview(oldestPr.created_at) }}
-          />
-          {"|"}
-          <Typography color="text.secondary">PRs: </Typography>
-          <Chip label={pulls.length} size="small" color="primary" />
+          {oldestOpenPr ? (
+            <Chip
+              label={Math.floor(
+                (new Date().getTime() - oldestOpenPr.created_at.getTime()) /
+                  (1000 * 3600 * 24)
+              )}
+              size="small"
+              sx={{
+                bgcolor: getColorForDaysInReview(oldestOpenPr.created_at),
+              }}
+            />
+          ) : (
+            <Typography color="text.secondary">N/A</Typography>
+          )}
+          {" | "}
+          <Typography color="text.secondary">Open PRs: </Typography>
+          <Chip label={openCount} size="small" color="primary" />
+          {" | "}
+          <Typography color="text.secondary">Draft PRs: </Typography>
+          <Chip label={draftCount} size="small" color="secondary" />
           <Link
             href={repo.html_url + "/pulls"}
             sx={{ marginLeft: "auto" }}


### PR DESCRIPTION
I’ve added a few updates to the dashboard that I hope you'll find useful:

**Separated PR Counts:** The total Pull Request count is now divided into two categories: Open and Draft
**Repository Sorting:**  Repositories are now sorted by the number of PRs, displayed in descending order
**Open PR Days:** Added a field to show the maximum days an open PR has been active. If no PRs are open, it displays "N/A"

Open to feedback or further ideas to enhance the dashboard

